### PR TITLE
feat: Add todo app example using oxidb and clap

### DIFF
--- a/examples/.gitkeep
+++ b/examples/.gitkeep
@@ -1,0 +1,1 @@
+# This file is intentionally left blank to ensure the directory is tracked by Git.

--- a/examples/todo_app/Cargo.toml
+++ b/examples/todo_app/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "todo_app"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4.5.4", features = ["derive"] }
+oxidb = { path = "../../../oxidb" } # Assuming oxidb is at the root of the repo
+tokio = { version = "1.37.0", features = ["full"] }

--- a/examples/todo_app/README.md
+++ b/examples/todo_app/README.md
@@ -1,0 +1,83 @@
+# Todo App Example
+
+This example demonstrates a simple command-line interface (CLI) todo application built with Rust. It uses `oxidb` for data storage and `clap` for parsing CLI arguments.
+
+## Purpose
+
+The primary purpose of this example is to showcase a basic integration of the `oxidb` database with a common Rust CLI pattern. You can add, list, and mark todo items as done.
+
+## Prerequisites
+
+- Rust and Cargo installed (https://www.rust-lang.org/tools/install)
+- The `oxidb` crate should be present in the parent directory (this example uses a path dependency `../../../oxidb`).
+
+## Building the Example
+
+To build the application, navigate to the root of the repository and run:
+
+```bash
+cargo build --manifest-path examples/todo_app/Cargo.toml
+```
+
+Alternatively, if you are already in the `examples/todo_app` directory, you can simply run:
+```bash
+cargo build
+```
+(This assumes you have a global `oxidb` crate or have adjusted the path in `Cargo.toml` if running standalone.)
+
+## Running the Example
+
+You can run the application directly using `cargo run`. All arguments after `--` will be passed to the application.
+
+Navigate to the root of the repository and run:
+
+### Add a new todo item
+```bash
+cargo run --manifest-path examples/todo_app/Cargo.toml -- add "Buy milk"
+cargo run --manifest-path examples/todo_app/Cargo.toml -- add "Read a book on Rust"
+```
+
+### List all todo items
+```bash
+cargo run --manifest-path examples/todo_app/Cargo.toml -- list
+```
+Expected output:
+```
+Using database at: todo_app.db
+Todo items:
+[ ] 1 - Buy milk
+[ ] 2 - Read a book on Rust
+```
+
+### Mark a todo item as done
+To mark the item with ID `1` ("Buy milk") as done:
+```bash
+cargo run --manifest-path examples/todo_app/Cargo.toml -- done 1
+```
+
+### List items again to see the change
+```bash
+cargo run --manifest-path examples/todo_app/Cargo.toml -- list
+```
+Expected output:
+```
+Using database at: todo_app.db
+Todo items:
+[x] 1 - Buy milk
+[ ] 2 - Read a book on Rust
+```
+
+## Available Commands
+
+The application supports the following commands:
+
+-   `add <DESCRIPTION>`: Adds a new todo item with the given description.
+    -   Example: `cargo run --manifest-path examples/todo_app/Cargo.toml -- add "Schedule meeting"`
+-   `list`: Lists all current todo items, showing their ID, status ([x] for done, [ ] for not done), and description.
+    -   Example: `cargo run --manifest-path examples/todo_app/Cargo.toml -- list`
+-   `done <ID>`: Marks the todo item with the specified ID as done.
+    -   Example: `cargo run --manifest-path examples/todo_app/Cargo.toml -- done 2`
+
+The todo items are stored in a local file named `todo_app.db` in the current directory where you run the command.
+If `todo_app.db` does not exist, it will be created automatically.
+If the `todos` table does not exist within the database, it will also be created automatically.

--- a/examples/todo_app/src/main.rs
+++ b/examples/todo_app/src/main.rs
@@ -1,0 +1,110 @@
+use oxidb::Oxidb;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Parser, Debug)]
+enum Commands {
+    /// Adds a new todo item
+    Add {
+        #[clap(value_parser)]
+        description: String,
+    },
+    /// Lists all todo items
+    List {},
+    /// Marks a todo item as done
+    Done {
+        #[clap(value_parser)]
+        id: u64,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct TodoItem {
+    id: u64,
+    description: String,
+    done: bool,
+}
+
+const TODO_TABLE: &str = "todos";
+const DB_PATH: &str = "todo_app.db";
+
+async fn ensure_table_exists(db: &Oxidb) -> Result<(), Box<dyn Error>> {
+    if !db.table_exists(TODO_TABLE).await? {
+        db.create_table::<TodoItem>(TODO_TABLE, "id").await?;
+        println!("Created table '{}'", TODO_TABLE);
+    }
+    Ok(())
+}
+
+async fn add_item(db: &Oxidb, description: String) -> Result<u64, Box<dyn Error>> {
+    ensure_table_exists(db).await?;
+    let items_table = db.table::<TodoItem>(TODO_TABLE).await?;
+    let new_item = TodoItem {
+        id: 0, // oxidb will generate an ID
+        description,
+        done: false,
+    };
+    let id = items_table.insert(new_item).await?;
+    println!("Added item with ID: {}", id);
+    Ok(id)
+}
+
+async fn list_items(db: &Oxidb) -> Result<(), Box<dyn Error>> {
+    ensure_table_exists(db).await?;
+    let items_table = db.table::<TodoItem>(TODO_TABLE).await?;
+    let all_items = items_table.get_all().await?;
+    if all_items.is_empty() {
+        println!("No todo items yet!");
+    } else {
+        println!("Todo items:");
+        for item in all_items {
+            println!("[{}] {} - {}", if item.done { "x" } else { " " }, item.id, item.description);
+        }
+    }
+    Ok(())
+}
+
+async fn mark_done(db: &Oxidb, id: u64) -> Result<(), Box<dyn Error>> {
+    ensure_table_exists(db).await?;
+    let items_table = db.table::<TodoItem>(TODO_TABLE).await?;
+    if let Some(mut item) = items_table.get(id).await? {
+        item.done = true;
+        items_table.update(id, item).await?;
+        println!("Marked item {} as done.", id);
+    } else {
+        println!("Item with ID {} not found.", id);
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
+
+    // Open the database. It will be created if it doesn't exist.
+    let db = Oxidb::new(DB_PATH).await?;
+    println!("Using database at: {}", DB_PATH);
+
+
+    match cli.command {
+        Commands::Add { description } => {
+            add_item(&db, description).await?;
+        }
+        Commands::List {} => {
+            list_items(&db).await?;
+        }
+        Commands::Done { id } => {
+            mark_done(&db, id).await?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This commit introduces a new todo application example in the `examples` directory. The application demonstrates the basic usage of `oxidb` for database operations and `clap` for command-line argument parsing.

The todo app allows you to:
- Add new todo items.
- List existing todo items.
- Mark todo items as done.

A README.md file is included with instructions on how to build and run the example. This example serves as a practical guide for using `oxidb` in Rust applications.